### PR TITLE
[bugfix] error: c.to_utf8() Cannot convert from `char[]' to `string'

### DIFF
--- a/src/Gtk/TerminalWindow.vala
+++ b/src/Gtk/TerminalWindow.vala
@@ -203,16 +203,8 @@ public class TerminalWindow : Gtk.Window {
 		process_quit(child_pid);
 	}
 
-/* builds in cosmic and disco
- * xenial fails with:
-Gtk/TerminalWindow.vala:242.19-242.29: error: Argument 1: Cannot convert from `char[]' to `string'
-                term.feed_child(c.to_utf8());
-                                ^^^^^^^^^^^
- */
-
 	public void execute_command(string command){
-		string c = command.concat("\n");
-		term.feed_child(c.to_utf8());
+		term.feed_child("%s\n".printf(command), -1);
 	}
 
 	public void execute_script(string script_path, bool wait = false){


### PR DESCRIPTION
this fixes [13] by using printf instead c.to_utf8()

[13] https://github.com/aljex/mainline/issues/13

Signed-off-by: Markus Heiser <markus.heiser@darmarit.de>